### PR TITLE
Add appmon dependency, remove '-mode embedded'

### DIFF
--- a/rel1/files/elevators
+++ b/rel1/files/elevators
@@ -241,7 +241,7 @@ case "$1" in
         BINDIR=$ROOTDIR/erts-$ERTS_VSN/bin
         EMU=beam
         PROGNAME=`echo $0 | sed 's/.*\\///'`
-        CMD="$BINDIR/erlexec -boot $RUNNER_BASE_DIR/releases/$APP_VSN/$BOOTFILE -mode embedded -config $CONFIG_PATH -args_file $VMARGS_PATH"
+        CMD="$BINDIR/erlexec -boot $RUNNER_BASE_DIR/releases/$APP_VSN/$BOOTFILE -config $CONFIG_PATH -args_file $VMARGS_PATH"
         export EMU
         export ROOTDIR
         export BINDIR

--- a/rel1/reltool.config
+++ b/rel1/reltool.config
@@ -7,6 +7,7 @@
          kernel,
          stdlib,
          sasl,
+         appmon,
          elevators
         ]},
        {rel, "start_clean", "",


### PR DESCRIPTION
Hi, Loïc, I've a couple of small patches here that IMHO are useful.
1. Add a dependency on the appmon app.  Then `appmon:start().` can be used to help see the supervisory processes tree for the elevators app as well as sasl and kernel.
2. Remove the `-mode embedded` flag from the `erl` command line.  Using embedded mode makes it difficult to load new modules, e.g., if someone is experimenting with some new elevator code and coincidentally to use a new module.

Also, the embedded mode is not included in DOS/Win `elevators.cmd` version of the script.
